### PR TITLE
feat : BaseDto와 BaseMapper 로 중복 매퍼로직 개선

### DIFF
--- a/backend/src/main/java/com/codestates/auth/config/MemberDetail.java
+++ b/backend/src/main/java/com/codestates/auth/config/MemberDetail.java
@@ -68,8 +68,6 @@ public class MemberDetail extends Member implements UserDetails, OAuth2User {
         return true;
     }
 
-
-
     @Override
     public String getName() {
         return attributes.get("sub").toString();

--- a/backend/src/main/java/com/codestates/auth/config/SecurityConfiguration.java
+++ b/backend/src/main/java/com/codestates/auth/config/SecurityConfiguration.java
@@ -61,6 +61,13 @@ public class SecurityConfiguration {
                 .and()
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
 
+//가독성을 위한 구성
+//                .oauth2Login()
+//                .userInfoEndpoint()
+//                .userService(oAuth2UserService)
+//                .and()
+//                .successHandler(oAuth2LoginSuccessHandler)
+//                .failureHandler(oAuth2LoginFailureHandler);
                 .oauth2Login()
                 .successHandler(oAuth2LoginSuccessHandler)
                 .failureHandler(oAuth2LoginFailureHandler)

--- a/backend/src/main/java/com/codestates/common/base/BaseDto.java
+++ b/backend/src/main/java/com/codestates/common/base/BaseDto.java
@@ -1,0 +1,51 @@
+package com.codestates.common.base;
+
+import com.codestates.tag.dto.TagDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class BaseDto {
+    @Getter
+    @Setter
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class FillRoomResponseDtos {
+        private Long roomId;
+        private String title;
+        private String info;
+        private int memberMaxCount;
+        private int memberCurrentCount;
+        @JsonProperty("image_url")
+        private String imageUrl;
+        @JsonProperty("is_private")
+        private boolean isPrivate;
+        private String password;
+        private int favoriteCount;
+        @JsonProperty("is_favorite")
+        private boolean isFavorite;
+        private List<TagDto.TagResponseDto> tags;
+
+        public FillRoomResponseDtos(Long roomId, String title, String info, int memberMaxCount, int memberCurrentCount, String imageUrl, boolean isPrivate, String password, int favoriteCount, boolean isFavorite) {
+            this.roomId = roomId;
+            this.title = title;
+            this.info = info;
+            this.memberMaxCount = memberMaxCount;
+            this.memberCurrentCount = memberCurrentCount;
+            this.imageUrl = imageUrl;
+            this.isPrivate = isPrivate;
+            this.password = password;
+            this.favoriteCount = favoriteCount;
+            this.isFavorite = isFavorite;
+        }
+    }
+}

--- a/backend/src/main/java/com/codestates/common/base/BaseMapper.java
+++ b/backend/src/main/java/com/codestates/common/base/BaseMapper.java
@@ -1,0 +1,48 @@
+package com.codestates.common.base;
+
+import com.codestates.member.entity.Member;
+import com.codestates.member.entity.MemberTag;
+import com.codestates.room.entity.Room;
+import com.codestates.room.entity.RoomTag;
+import com.codestates.tag.dto.TagDto;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public interface BaseMapper {
+    default BaseDto.FillRoomResponseDtos fillRoomDatas_Member(Room room, Member member) {
+        BaseDto.FillRoomResponseDtos responseDtos = new BaseDto.FillRoomResponseDtos();
+        responseDtos.setRoomId(room.getRoomId());
+        responseDtos.setTitle(room.getTitle());
+        responseDtos.setInfo(room.getInfo());
+        responseDtos.setMemberMaxCount(room.getMemberMaxCount());
+        responseDtos.setImageUrl(room.getImageUrl());
+        responseDtos.setPrivate(room.isPrivate());
+        responseDtos.setPassword(room.getPassword());
+        responseDtos.setFavoriteCount(room.getFavoriteCount());
+        responseDtos.setFavorite(room.getFavoriteRoomList().stream().anyMatch(favorite -> favorite.getMember().equals(member) && favorite.isFavorite()));
+        responseDtos.setTags(getRoomTags(room.getRoomTagList()));
+        return responseDtos;
+    }
+
+    default List<TagDto.TagResponseDto> getRoomTags(List<RoomTag> roomTagList) {
+        return roomTagList.stream()
+                .map(memberRoom -> {
+                    TagDto.TagResponseDto memberRoomTagDtos = new TagDto.TagResponseDto();
+                    memberRoomTagDtos.setRoomId(memberRoom.getRoom().getRoomId());
+                    memberRoomTagDtos.setTagId(memberRoom.getTag().getTagId());
+                    memberRoomTagDtos.setName(memberRoom.getTag().getName());
+                    return memberRoomTagDtos;
+                })
+                .collect(Collectors.toList());
+    }
+
+    default List<TagDto.TagResponseDto> getMemberTags(List<MemberTag> memberTagList) {
+        return memberTagList.stream()
+                .map(memberTag -> {
+                    TagDto.TagResponseDto memberTagDtos = new TagDto.TagResponseDto();
+                    memberTagDtos.setTagId(memberTag.getTag().getTagId());
+                    memberTagDtos.setName(memberTag.getTag().getName());
+                    return memberTagDtos;
+                }).collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/codestates/common/history/RoomHistoryController.java
+++ b/backend/src/main/java/com/codestates/common/history/RoomHistoryController.java
@@ -3,7 +3,6 @@ package com.codestates.common.history;
 import com.codestates.auth.utils.ErrorResponse;
 import com.codestates.common.response.MultiResponseDto;
 import com.codestates.room.mapper.RoomMapper;
-import com.codestates.room.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -12,8 +11,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.constraints.Positive;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -36,7 +33,7 @@ public class RoomHistoryController {
     public ResponseEntity getUserRoomHistories(@PathVariable("member-id") Long memberId,
                                                @RequestParam(value = "page", defaultValue = "1") @Positive int page,
                                                @RequestParam(value = "size", defaultValue = "10") @Positive int size,
-                                                  Authentication authentication) {
+                                               Authentication authentication) {
 
         Map<String, Object> principal = (Map<String, Object>) authentication.getPrincipal();
         long jwtMemberId = ((Number) principal.get("memberId")).longValue();

--- a/backend/src/main/java/com/codestates/common/search/SearchService.java
+++ b/backend/src/main/java/com/codestates/common/search/SearchService.java
@@ -1,6 +1,7 @@
 package com.codestates.common.search;
 
 import com.codestates.common.sort.SortMethod;
+import com.codestates.favorite.Favorite;
 import com.codestates.member.entity.MemberRoom;
 import com.codestates.room.dto.RoomDto;
 import com.codestates.room.entity.Room;
@@ -85,11 +86,12 @@ public class SearchService {
                 .MemberMaxCount(room.getMemberMaxCount())
                 .MemberCurrentCount(room.getMemberCurrentCount())
                 .isPrivate(room.isPrivate())
-                .favoriteStatus(memberRoom.getFavorite())
+                .isFavorite(room.getFavoriteRoomList().stream().anyMatch(Favorite::isFavorite))//불러와 진다!
                 .favoriteCount(room.getFavoriteCount())
                 .createdAt(LocalDateTime.now())
                 .tags(tagResponseDtos).build();
     }
+
 
 
 

--- a/backend/src/main/java/com/codestates/member/dto/MemberDto.java
+++ b/backend/src/main/java/com/codestates/member/dto/MemberDto.java
@@ -2,6 +2,7 @@ package com.codestates.member.dto;
 
 import com.codestates.member.entity.MemberRoom;
 import com.codestates.member.entity.MemberTag;
+import com.codestates.tag.dto.TagDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -53,8 +54,9 @@ public class MemberDto {
     }
 
 
-    @Getter
-    @Setter
+    @Getter @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class PatchResponseDto {
         private long memberId;
@@ -62,7 +64,7 @@ public class MemberDto {
         private String email;
         @JsonProperty("image_url")
         private String imageUrl;
-        private List<MemberTagDtos> tags;
+        private List<TagDto.TagResponseDto> tags;
     }
 
 

--- a/backend/src/main/java/com/codestates/member/entity/Member.java
+++ b/backend/src/main/java/com/codestates/member/entity/Member.java
@@ -3,7 +3,6 @@ package com.codestates.member.entity;
 import com.codestates.common.entity.BaseEntity;
 import com.codestates.common.history.RoomHistory;
 import com.codestates.favorite.Favorite;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -86,7 +85,7 @@ public class Member extends BaseEntity {
 
     //리팩토링 1차
     @Builder
-    public Member(Long memberId, String email, String password, String nickname, String imageUrl, int favoriteCount, int createdCount, int recordeCount, Boolean isAdmin, boolean isVoted, LocalDateTime deletionDate, MemberStatus status, List<MemberRoom> memberRoomList, List<MemberTag> memberTagList, List<RoomHistory> roomHistoryList, String provider, String providerId, List<String> roles, List<Favorite> favoriteList) {
+    public Member(Long memberId, String email, String password, String nickname, String imageUrl, int favoriteCount, int createdCount, int recordeCount, Boolean isAdmin, boolean isVoted, LocalDateTime deletionDate, List<MemberRoom> memberRoomList, List<MemberTag> memberTagList, List<RoomHistory> roomHistoryList, String provider, String providerId, List<String> roles, List<Favorite> favoriteList) {
         this.memberId = memberId;
         this.email = email;
         this.password = password;

--- a/backend/src/main/java/com/codestates/member/mapper/MemberMapper.java
+++ b/backend/src/main/java/com/codestates/member/mapper/MemberMapper.java
@@ -1,39 +1,26 @@
 package com.codestates.member.mapper;
 
+import com.codestates.common.base.BaseDto;
+import com.codestates.common.base.BaseMapper;
 import com.codestates.member.dto.MemberDto;
-import com.codestates.member.dto.MemberRoomTagDtos;
-import com.codestates.member.dto.MemberTagDtos;
 import com.codestates.member.entity.Member;
 import com.codestates.member.entity.MemberRoom;
-import com.codestates.member.entity.MemberTag;
-import com.codestates.room.dto.RoomDto;
-import com.codestates.room.entity.Room;
-import com.codestates.room.entity.RoomTag;
-import com.codestates.tag.dto.TagDto;
-import com.codestates.tag.entity.Tag;
 import org.mapstruct.Mapper;
-
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
 
 @Mapper(componentModel = "spring")
-public interface MemberMapper {
+public interface MemberMapper extends BaseMapper {
     Member postDtoToMember(MemberDto.Post requestBody);
-
     Member patchNicknameDtoToMember(MemberDto.PatchNickname requestBody);
-
     Member patchImageDtoToMember(MemberDto.PatchImage requestBody);
-
 
     default MemberDto.PatchImageResponseDto memberToPatchImageResponseDto(Member responseMember) {
         if (responseMember == null) return null;
         MemberDto.PatchImageResponseDto responseDto = new MemberDto.PatchImageResponseDto();
         responseDto.setMemberId(responseMember.getMemberId());
         responseDto.setImageUrl(responseMember.getImageUrl());
-
         return responseDto;
     }
 
@@ -49,87 +36,15 @@ public interface MemberMapper {
         patchResponseDto.setEmail(createMember.getEmail());
         patchResponseDto.setImageUrl(createMember.getImageUrl());
         patchResponseDto.setTags(getMemberTags(createMember.getMemberTagList()));
-
         return patchResponseDto;
     }
 
-    default List<MemberTagDtos> getMemberTags(List<MemberTag> memberTagList) {
 
-        return memberTagList.stream()
-                .map(memberTag -> {
-                    MemberTagDtos memberTagDtos = new MemberTagDtos();
-                    memberTagDtos.setTagId(memberTag.getTag().getTagId());
-                    memberTagDtos.setName(memberTag.getTag().getName());
-                    return memberTagDtos;
-
-                }).collect(Collectors.toList());
-    }
-
-
-    //Todo : 찜한채팅방 목록
-    default List<MemberDto.LikeRoomResponseDtos> memberToLikeResponseDtos(List<MemberRoom> memberRoomList, long memberId) {
-
-        return memberRoomList.stream()
-                .filter(memberRoom -> memberRoom.getMember().getMemberId() == memberId && memberRoom.getFavorite().equals(MemberRoom.Favorite.LIKE))
-                .map(room -> {
-                    MemberDto.LikeRoomResponseDtos responseDtos = new MemberDto.LikeRoomResponseDtos();
-                    responseDtos.setRoomId(room.getMemberRoomId());
-                    responseDtos.setTitle(room.getRoom().getTitle());
-                    responseDtos.setInfo(room.getRoom().getInfo());
-                    responseDtos.setImageUrl(room.getRoom().getImageUrl());
-                    responseDtos.setFavoriteCount(room.getRoom().getFavoriteCount());
-                    responseDtos.setMemberMaxCount(room.getRoom().getMemberMaxCount());
-                    //responseDtos.setMemberCurrentCount(room.getRoom().getMemberCurrentCount());
-                    responseDtos.setPrivate(room.getRoom().isPrivate());
-                    responseDtos.setPassword(room.getRoom().getPassword());
-                    responseDtos.setFavoriteStatus(room.getFavorite());
-                    responseDtos.setTags(getRoomTags(room.getRoom().getRoomTagList()));
-                    return responseDtos;
-                })
-                .collect(Collectors.toList());
-    }
-
-    default List<MemberRoomTagDtos> getRoomTags(List<RoomTag> roomTagList) {
-        return roomTagList.stream()
-                .map(memberRoom -> {
-                    MemberRoomTagDtos memberRoomTagDtos = new MemberRoomTagDtos();
-                    memberRoomTagDtos.setRoomId(memberRoom.getRoom().getRoomId());
-                    memberRoomTagDtos.setTagId(memberRoom.getTag().getTagId());
-                    memberRoomTagDtos.setName(memberRoom.getTag().getName());
-                    return memberRoomTagDtos;
-                })
-                .collect(Collectors.toList());
-    }
-
-
-    //Todo : 생성한채팅방 목록
-    default List<MemberDto.CreatedRoomResponseDtos> memberToCreatedResponseDtos(List<MemberRoom> memberRoomList) {
+    //Todo : 생성한 채팅방 목록
+    default List<BaseDto.FillRoomResponseDtos> memberToCreatedResponseDtos(List<MemberRoom> memberRoomList) {
         return memberRoomList.stream()
                 .filter(memberRoom -> memberRoom.getAuthority().equals(MemberRoom.Authority.ADMIN))
-                .map(MemberRoom::getRoom)
-                .map(room -> {
-                    MemberDto.CreatedRoomResponseDtos responseDtos = new MemberDto.CreatedRoomResponseDtos();
-                    responseDtos.setRoomId(room.getRoomId());
-                    responseDtos.setTitle(room.getTitle());
-                    responseDtos.setInfo(room.getInfo());
-                    responseDtos.setImageUrl(room.getImageUrl());
-                    responseDtos.setFavoriteCount(room.getFavoriteCount());
-                    responseDtos.setFavoriteStatus(getRoomFavorite(room, room.getMemberRoomList()));
-                    responseDtos.setMemberMaxCount(room.getMemberMaxCount());
-                    //responseDtos.setMemberCurrentCount(room.getMemberCurrentCount());
-                    responseDtos.setPrivate(room.isPrivate());
-                    responseDtos.setPassword(room.getPassword());
-                    responseDtos.setTags(getRoomTags(room.getRoomTagList()));
-                    return responseDtos;
-                })
+                .map(memberRoom -> this.fillRoomDatas_Member(memberRoom.getRoom(), memberRoom.getMember()))
                 .collect(Collectors.toList());
-    }
-
-    default MemberRoom.Favorite getRoomFavorite(Room room, List<MemberRoom> memberRoomList) {
-        if (memberRoomList == null) {
-            return null;
-        }
-        MemberRoom memberRoom = memberRoomList.stream().filter(r -> r.getRoom().getRoomId().equals(room.getRoomId())).findFirst().get();
-        return memberRoom.getFavorite();
     }
 }

--- a/backend/src/main/java/com/codestates/room/dto/RoomDto.java
+++ b/backend/src/main/java/com/codestates/room/dto/RoomDto.java
@@ -1,26 +1,22 @@
 package com.codestates.room.dto;
 
-import com.codestates.member.entity.MemberRoom;
-import com.codestates.room.entity.Room;
 import com.codestates.tag.dto.TagDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
-
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Positive;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Getter
-@Setter
+@Getter @Setter
 public class RoomDto {
 
-    @Getter
-    @Setter
+
+    @Getter @Setter
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public static class Post {
+    public static class Post{
         @JsonProperty("admin_member_id")
         private long adminMemberId;
         private String title;
@@ -35,32 +31,7 @@ public class RoomDto {
     }
 
 
-
-    @Getter
-    @Setter
-    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public static class PostFavorite {
-        private long roomId;
-        private long memberId;
-        @JsonProperty("is_favorite")
-        private boolean isFavorite;
-    }
-
-
-
-    @Getter
-    @Setter
-    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public static class PostUndoFavorite {
-        private long memberId;
-        @JsonProperty("is_favorite")
-        private boolean isFavorite;
-    }
-
-
-
-    @Getter
-    @Setter
+    @Getter @Setter
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class PostResponseDto {
         private long roomId;
@@ -81,10 +52,9 @@ public class RoomDto {
 
 
 
-    @Getter
-    @Setter
+    @Getter @Setter
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public static class Patch {
+    public static class Patch{
         private long roomId;
         @JsonProperty("admin_member_id")
         private long adminMemberId;
@@ -94,14 +64,13 @@ public class RoomDto {
         @JsonProperty("is_private")
         private boolean isPrivate;
         private String password;
-        private List<RoomTagDto> tags;
+        private List<TagDto.TagResponseDto> tags;
     }
 
 
 
     //Todo: 방수정 응답
-    @Getter
-    @Setter
+    @Getter @Setter
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class PatchResponseDto {
         private long roomId;
@@ -117,28 +86,25 @@ public class RoomDto {
         private boolean isPrivate;
         private String password;
         private int favoriteCount;
-        @JsonProperty("favorite_status")
-        private MemberRoom.Favorite favoriteStatus;
+        @JsonProperty("is_favorite")
+        private boolean isFavorite;
         private List<TagDto.TagResponseDto> tags;
     }
 
 
 
-    @Getter
-    @Setter
+    @Getter @Setter
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class PatchAdmin {
         @Positive
         private long roomId;
-        @Positive
-        @JsonProperty("new_admin_id")
+        @Positive @JsonProperty("new_admin_id")
         private long newAdminId;
     }
 
 
 
-    @Getter
-    @Setter
+    @Getter @Setter
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class PatchAdminResponseDto {
         @Positive
@@ -153,10 +119,9 @@ public class RoomDto {
 
 
 
-    @Getter
-    @Setter
+    @Getter @Setter
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public static class GetNewRoomResponseDtos {
+    public static class GetRoomResponseDtos {
         @Positive
         private long roomId;
         @NotBlank
@@ -169,42 +134,17 @@ public class RoomDto {
         @JsonProperty("is_private")
         private boolean isPrivate;
         private String password;
-        @Positive
         private int favoriteCount;
-        private MemberRoom.Favorite favoriteStatus;
+        @JsonProperty("is_favorite")
+        private boolean isFavorite;
+        @JsonProperty("created_at")
+        private LocalDateTime createdAt;
         private List<TagDto.TagResponseDto> tags;
     }
 
 
 
-    @Getter
-    @Setter
-    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public static class GetRecommendRoomResponseDtos {
-        @Positive
-        private long roomId;
-        @NotBlank
-        private String title;
-        private String info;
-        @JsonProperty("image_url")
-        private String imageUrl;
-        private int MemberMaxCount;
-        private int MemberCurrentCount;
-        @JsonProperty("is_private")
-        private boolean isPrivate;
-        private String password;
-        @Positive
-        private int favoriteCount;
-        @JsonProperty("favorite_status")
-        private MemberRoom.Favorite favoriteStatus;
-        private List<TagDto.TagResponseDto> tags;
-    }
-
-
-
-    @Getter
-    @Setter
-    @Builder
+    @Getter @Setter @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -220,42 +160,17 @@ public class RoomDto {
         private boolean isPrivate;
         private String password;
         private int favoriteCount;
-        @JsonProperty("favorite_status")
-        private MemberRoom.Favorite favoriteStatus;
+        @JsonProperty("is_favorite")
+        private boolean isFavorite;
         @JsonProperty("created_at")
         private LocalDateTime createdAt;
         private List<TagDto.TagResponseDto> tags;
     }
 
 
-    @Getter
-    @Setter
-    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public static class DeleteResponseDto {
-        private long adminMemberId;
-    }
-
-
-    @Getter
-    @Setter
+    @Getter @Setter
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class CheckTitle {
         private String title;
     }
-
-
-
-    //Todo : 방장정보 DTO (사용X)
-    @Getter
-    @Setter
-    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public static class RoomAdminDto {
-        @JsonProperty("admin_member_id")
-        private long adminMemberId;
-        @JsonProperty("admin_nickname")
-        private String adminNickname;
-        @JsonProperty("image_url")
-        private String imageUrl;
-    }
-
 }

--- a/backend/src/main/java/com/codestates/tag/controller/TagController.java
+++ b/backend/src/main/java/com/codestates/tag/controller/TagController.java
@@ -1,5 +1,6 @@
 package com.codestates.tag.controller;
 
+import com.codestates.common.base.BaseDto;
 import com.codestates.common.response.MultiResponseDto;
 import com.codestates.room.entity.Room;
 import com.codestates.tag.dto.TagCustomResponseDto;
@@ -35,7 +36,7 @@ public class TagController {
 
         Page<Room> roomTagPage = tagService.findTagSortedByFavorite(page - 1, size, tagId, sort);
         List<Room> roomTagList = roomTagPage.getContent();
-        List<TagDto.GetRoomTagResponseDto> tagResponseDtoList = mapper.tagToRoomTagResponseDto(roomTagList);
+        List<BaseDto.FillRoomResponseDtos> tagResponseDtoList = mapper.tagToRoomTagResponseDto(roomTagList);
 
         Tag tag = tagService.findVerifiedTag(tagId);
         String name = tag.getName();

--- a/backend/src/main/java/com/codestates/tag/dto/TagCustomResponseDto.java
+++ b/backend/src/main/java/com/codestates/tag/dto/TagCustomResponseDto.java
@@ -1,7 +1,7 @@
 package com.codestates.tag.dto;
 
+import com.codestates.common.base.BaseDto;
 import com.codestates.common.response.PageInfo;
-import com.codestates.room.entity.RoomTag;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
@@ -13,10 +13,10 @@ import java.util.List;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TagCustomResponseDto {
     private String name;
-    private List<TagDto.GetRoomTagResponseDto> data;
+    private List<BaseDto.FillRoomResponseDtos> data;
     private PageInfo pageInfo;
 
-    public TagCustomResponseDto(String name, List<TagDto.GetRoomTagResponseDto> data, Page page) {
+    public TagCustomResponseDto(String name, List<BaseDto.FillRoomResponseDtos> data, Page page) {
         this.name = name;
         this.data = data;
         this.pageInfo = new PageInfo(page.getNumber()+1, page.getSize(), page.getTotalElements(), page.getTotalPages());

--- a/backend/src/main/java/com/codestates/tag/dto/TagDto.java
+++ b/backend/src/main/java/com/codestates/tag/dto/TagDto.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Positive;
 import java.util.List;
 
 @Getter
@@ -51,9 +53,17 @@ public class TagDto {
     @NoArgsConstructor
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class TagResponseDto {
+        @Positive
         private long tagId;
+        @Positive
+        private long roomId;
+        @NotBlank
         private String name;
 
+        public TagResponseDto(long tagId, String name) {
+            this.tagId = tagId;
+            this.name = name;
+        }
     }
 
 

--- a/backend/src/main/java/com/codestates/tag/mapper/TagMapper.java
+++ b/backend/src/main/java/com/codestates/tag/mapper/TagMapper.java
@@ -1,71 +1,27 @@
 package com.codestates.tag.mapper;
 
-import com.codestates.member.entity.MemberRoom;
+import com.codestates.common.base.BaseDto;
+import com.codestates.common.base.BaseMapper;
+import com.codestates.member.entity.Member;
 import com.codestates.room.entity.Room;
-import com.codestates.room.entity.RoomTag;
 import com.codestates.tag.dto.TagDto;
 import com.codestates.tag.entity.Tag;
 import org.mapstruct.Mapper;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
-public interface TagMapper {
-
-
+public interface TagMapper extends BaseMapper { //리팩토링 1차
 
     //Todo : 태그조회 (해당태그를 사용한 스터디룸 목록조회)
-    default List<TagDto.GetRoomTagResponseDto> tagToRoomTagResponseDto(List<Room> roomTagList) {
+    default List<BaseDto.FillRoomResponseDtos> tagToRoomTagResponseDto(List<Room> roomTagList) {
         if (roomTagList == null) return null;
-        List<TagDto.GetRoomTagResponseDto> list = new ArrayList<TagDto.GetRoomTagResponseDto>(roomTagList.size());
-
-        for (Room room : roomTagList) {
-            list.add(getRoomContainsTag(room));
-        }
+        List<BaseDto.FillRoomResponseDtos> list = new ArrayList<BaseDto.FillRoomResponseDtos>(roomTagList.size());
+        for (Room room : roomTagList)
+            list.add(fillRoomDatas_Member(room, new Member())); //쓸모없는 Member 객체 생성 이부분 개선필요함!
         return list;
     }
 
-    default TagDto.GetRoomTagResponseDto getRoomContainsTag(Room room) {
-        if (room == null) return null;
-
-        TagDto.GetRoomTagResponseDto responseDto = new TagDto.GetRoomTagResponseDto();
-        responseDto.setRoomId(room.getRoomId());
-        responseDto.setTitle(room.getTitle());
-        responseDto.setInfo(room.getInfo());
-        responseDto.setImageUrl(room.getImageUrl());
-        responseDto.setPrivate(room.isPrivate());
-        responseDto.setPassword(room.getPassword());
-        responseDto.setFavoriteCount(room.getFavoriteCount());
-        responseDto.setFavoriteStatus(getRoomFavorite(room, room.getMemberRoomList()));
-        responseDto.setMemberMaxCount(room.getMemberMaxCount());
-        responseDto.setTags(getRoomTags(room.getRoomTagList()));
-
-        return responseDto;
-    }
-
-    default MemberRoom.Favorite getRoomFavorite(Room room, List<MemberRoom> memberRoomList) {
-        if (memberRoomList == null) return null;
-        MemberRoom memberRoom = memberRoomList.stream()
-                .filter(r -> r.getRoom().getRoomId().equals(room.getRoomId())).findFirst().get();
-
-        return memberRoom.getFavorite();
-    }
-
-    default List<TagDto.TagResponseDto> getRoomTags(List<RoomTag> roomTagList) {
-
-        return roomTagList.stream()
-                .map(memberRoom -> {
-                    TagDto.TagResponseDto tagResponseDto = new TagDto.TagResponseDto();
-                    tagResponseDto.setTagId(memberRoom.getTag().getTagId());
-                    tagResponseDto.setName(memberRoom.getTag().getName());
-                    return tagResponseDto;
-                })
-                .collect(Collectors.toList());
-    }
-
-
     List<TagDto.TagResponseDto> tagToGetTagResponseDtos(List<Tag> tagList);
 }
-


### PR DESCRIPTION
- BaseDto와 BaseMapper 로 중복 매퍼로직 개선
- BaseDto와 BaseMapper 사용으로 인한 Room과 Member 응답객체, 인자 변경
- 불필요한 import 등등 제거
